### PR TITLE
Fix network share command

### DIFF
--- a/GTA V - X Drive Batch Files/Connect_X_Drive.bat
+++ b/GTA V - X Drive Batch Files/Connect_X_Drive.bat
@@ -16,7 +16,8 @@ echo ------------------------------------------------------
 pause
 
 REM Create the network share using the drive letter and path
-net use X: \\localhost\%driveletter%$\%folderpath:~3% /persistent:yes
+net use \\localhost\* /delete
+net use X: "\\localhost\%driveletter%$\%folderpath:~3%"
 
 echo Drive mapped successfully to X: using path \\localhost\%driveletter%$\%folderpath:~3%
 pause

--- a/GTA V - X Drive Batch Files/Disconnect_X_Drive.bat
+++ b/GTA V - X Drive Batch Files/Disconnect_X_Drive.bat
@@ -1,6 +1,7 @@
 @echo off
 REM Disconnect the X: drive
 net use X: /delete
+net use \\localhost\* /delete
 
 REM Check if the disconnection was successful
 if %errorlevel% equ 0 (


### PR DESCRIPTION
Fix for `System error 86 has occurred` on Windows 11